### PR TITLE
fix(modules): updated helplink

### DIFF
--- a/src/simulator/src/modules/ALU.js
+++ b/src/simulator/src/modules/ALU.js
@@ -196,5 +196,5 @@ ALU.prototype.tooltipText =
  * @type {string}
  * @category modules
  */
-ALU.prototype.helplink = 'https://docs.circuitverse.org/#/miscellaneous?id=alu'
+ALU.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/8misc?id=alu'
 ALU.prototype.objectType = 'ALU'

--- a/src/simulator/src/modules/Adder.js
+++ b/src/simulator/src/modules/Adder.js
@@ -103,5 +103,5 @@ export default class Adder extends CircuitElement {
  */
 Adder.prototype.tooltipText = 'Adder ToolTip : Performs addition of numbers.'
 Adder.prototype.helplink =
-    'https://docs.circuitverse.org/#/miscellaneous?id=adder'
+    'https://docs.circuitverse.org/#/chapter4/8misc?id=adder'
 Adder.prototype.objectType = 'Adder'

--- a/src/simulator/src/modules/AndGate.js
+++ b/src/simulator/src/modules/AndGate.js
@@ -164,5 +164,5 @@ AndGate.prototype.verilogType = 'and'
  * @category modules
  */
 AndGate.prototype.changeInputSize = changeInputSize
-AndGate.prototype.helplink = 'https://docs.circuitverse.org/#/gates?id=and-gate'
+AndGate.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/4gates?id=and-gate'
 AndGate.prototype.objectType = 'AndGate'

--- a/src/simulator/src/modules/Arrow.js
+++ b/src/simulator/src/modules/Arrow.js
@@ -79,5 +79,5 @@ export default class Arrow extends CircuitElement {
  */
 Arrow.prototype.tooltipText = 'Arrow ToolTip : Arrow Selected.'
 Arrow.prototype.propagationDelayFixed = true
-Arrow.prototype.helplink = 'https://docs.circuitverse.org/#/annotation?id=arrow'
+Arrow.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/7annotation?id=arrow'
 Arrow.prototype.objectType = 'Arrow'

--- a/src/simulator/src/modules/BitSelector.js
+++ b/src/simulator/src/modules/BitSelector.js
@@ -153,7 +153,7 @@ export default class BitSelector extends CircuitElement {
 BitSelector.prototype.tooltipText =
     'BitSelector ToolTip : Divides input bits into several equal-sized groups.'
 BitSelector.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=bit-selector'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=bitselector'
 
 /**
  * @memberof BitSelector

--- a/src/simulator/src/modules/Buffer.js
+++ b/src/simulator/src/modules/Buffer.js
@@ -130,5 +130,5 @@ export default class Buffer extends CircuitElement {
 Buffer.prototype.tooltipText =
     'Buffer ToolTip : Isolate the input from the output.'
 Buffer.prototype.helplink =
-    'https://docs.circuitverse.org/#/miscellaneous?id=buffer'
+    'https://docs.circuitverse.org/#/chapter4/8misc?id=buffer'
 Buffer.prototype.objectType = 'Buffer'

--- a/src/simulator/src/modules/Button.js
+++ b/src/simulator/src/modules/Button.js
@@ -172,7 +172,7 @@ Button.prototype.tooltipText =
  * @category modules
  */
 Button.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=button'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=button'
 
 /**
  * @memberof Button

--- a/src/simulator/src/modules/ConstantVal.js
+++ b/src/simulator/src/modules/ConstantVal.js
@@ -198,7 +198,7 @@ ConstantVal.prototype.tooltipText =
  * @category modules
  */
 ConstantVal.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=constantval'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=constantval'
 
 /**
  * @memberof ConstantVal

--- a/src/simulator/src/modules/Counter.js
+++ b/src/simulator/src/modules/Counter.js
@@ -182,7 +182,7 @@ export default class Counter extends CircuitElement {
 Counter.prototype.tooltipText =
     'Counter: a binary counter from zero to a given maximum value'
 Counter.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=counter'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=counter'
 Counter.prototype.objectType = 'Counter'
 Counter.prototype.objectType = 'Counter'
 Counter.prototype.canShowInSubcircuit = true

--- a/src/simulator/src/modules/Decoder.js
+++ b/src/simulator/src/modules/Decoder.js
@@ -287,5 +287,5 @@ export default class Decoder extends CircuitElement {
 Decoder.prototype.tooltipText =
     'Decoder ToolTip : Converts coded inputs into coded outputs.'
 Decoder.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=decoder'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=decoder'
 Decoder.prototype.objectType = 'Decoder'

--- a/src/simulator/src/modules/DigitalLed.js
+++ b/src/simulator/src/modules/DigitalLed.js
@@ -169,7 +169,7 @@ DigitalLed.prototype.tooltipText =
  * @category modules
  */
 DigitalLed.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=digital-led'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=digital-led'
 
 /**
  * @memberof DigitalLed

--- a/src/simulator/src/modules/Flag.js
+++ b/src/simulator/src/modules/Flag.js
@@ -214,7 +214,7 @@ Flag.prototype.helplink =
  * @category modules
  */
 Flag.prototype.helplink =
-    'https://docs.circuitverse.org/#/miscellaneous?id=tunnel'
+    'https://docs.circuitverse.org/#/chapter4/8misc?id=tunnel'
 
 /**
  * @memberof Flag

--- a/src/simulator/src/modules/Ground.js
+++ b/src/simulator/src/modules/Ground.js
@@ -118,7 +118,7 @@ Ground.prototype.tooltipText = 'Ground: All bits are Low(0).'
  * @category modules
  */
 Ground.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=ground'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=ground'
 
 /**
  * @memberof Ground

--- a/src/simulator/src/modules/HexDisplay.js
+++ b/src/simulator/src/modules/HexDisplay.js
@@ -395,7 +395,7 @@ HexDisplay.prototype.tooltipText =
  * @category modules
  */
 HexDisplay.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=hex-display'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=hexdisplay'
 HexDisplay.prototype.objectType = 'HexDisplay'
 HexDisplay.prototype.canShowInSubcircuit = true
 HexDisplay.prototype.layoutProperties = {

--- a/src/simulator/src/modules/Input.js
+++ b/src/simulator/src/modules/Input.js
@@ -199,7 +199,7 @@ Input.prototype.tooltipText =
  * @category modules
  */
 Input.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=input'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=input'
 
 /**
  * @memberof Input

--- a/src/simulator/src/modules/LSB.js
+++ b/src/simulator/src/modules/LSB.js
@@ -140,5 +140,5 @@ export default class LSB extends CircuitElement {
 LSB.prototype.tooltipText =
     'LSB ToolTip : The least significant bit or the low-order bit.'
 LSB.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=least-significant-bit-lsb-detector'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=least-significant-bit-lsb-detector'
 LSB.prototype.objectType = 'LSB'

--- a/src/simulator/src/modules/MSB.js
+++ b/src/simulator/src/modules/MSB.js
@@ -137,5 +137,5 @@ export default class MSB extends CircuitElement {
 MSB.prototype.tooltipText =
     'MSB ToolTip : The most significant bit or the high-order bit.'
 MSB.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=most-significant-bit-msb-detector'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=most-significant-bit-msb-detector'
 MSB.prototype.objectType = 'MSB'

--- a/src/simulator/src/modules/Multiplexer.js
+++ b/src/simulator/src/modules/Multiplexer.js
@@ -324,7 +324,7 @@ export default class Multiplexer extends CircuitElement {
 Multiplexer.prototype.tooltipText =
     'Multiplexer ToolTip : Multiple inputs and a single line output.'
 Multiplexer.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=multiplexer'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=multiplexer'
 
 /**
  * @memberof Multiplexer

--- a/src/simulator/src/modules/NandGate.js
+++ b/src/simulator/src/modules/NandGate.js
@@ -165,5 +165,5 @@ NandGate.prototype.changeInputSize = changeInputSize
  */
 NandGate.prototype.verilogType = 'nand'
 NandGate.prototype.helplink =
-    'https://docs.circuitverse.org/#/gates?id=nand-gate'
+    'https://docs.circuitverse.org/#/chapter4/4gates?id=nand-gate'
 NandGate.prototype.objectType = 'NandGate'

--- a/src/simulator/src/modules/NorGate.js
+++ b/src/simulator/src/modules/NorGate.js
@@ -179,5 +179,5 @@ NorGate.prototype.changeInputSize = changeInputSize
  * @category modules
  */
 NorGate.prototype.verilogType = 'nor'
-NorGate.prototype.helplink = 'https://docs.circuitverse.org/#/gates?id=nor-gate'
+NorGate.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/4gates?id=nor-gate'
 NorGate.prototype.objectType = 'NorGate'

--- a/src/simulator/src/modules/NotGate.js
+++ b/src/simulator/src/modules/NotGate.js
@@ -108,6 +108,6 @@ export default class NotGate extends CircuitElement {
  */
 NotGate.prototype.tooltipText =
     'Not Gate Tooltip : Inverts the input digital signal.'
-NotGate.prototype.helplink = 'https://docs.circuitverse.org/#/gates?id=not-gate'
+NotGate.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/4gates?id=not-gate'
 NotGate.prototype.objectType = 'NotGate'
 NotGate.prototype.verilogType = 'not'

--- a/src/simulator/src/modules/OrGate.js
+++ b/src/simulator/src/modules/OrGate.js
@@ -171,5 +171,5 @@ OrGate.prototype.alwaysResolve = true
  * @category modules
  */
 OrGate.prototype.verilogType = 'or'
-OrGate.prototype.helplink = 'https://docs.circuitverse.org/#/gates?id=or-gate'
+OrGate.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/4gates?id=or-gate'
 OrGate.prototype.objectType = 'OrGate'

--- a/src/simulator/src/modules/Output.js
+++ b/src/simulator/src/modules/Output.js
@@ -208,7 +208,7 @@ Output.prototype.tooltipText =
  * @type {string}
  * @category modules
  */
-Output.prototype.helplink = 'https://docs.circuitverse.org/#/outputs?id=output'
+Output.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/3output?id=output'
 
 /**
  * @memberof Output

--- a/src/simulator/src/modules/Power.js
+++ b/src/simulator/src/modules/Power.js
@@ -101,7 +101,7 @@ Power.prototype.tooltipText = 'Power: All bits are High(1).'
  * @category modules
  */
 Power.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=power'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=power'
 
 /**
  * @memberof Power

--- a/src/simulator/src/modules/PriorityEncoder.js
+++ b/src/simulator/src/modules/PriorityEncoder.js
@@ -272,5 +272,5 @@ export default class PriorityEncoder extends CircuitElement {
 PriorityEncoder.prototype.tooltipText =
     'Priority Encoder ToolTip : Compresses binary inputs into a smaller number of outputs.'
 PriorityEncoder.prototype.helplink =
-    'https://docs.circuitverse.org/#/decodersandplexers?id=priority-encoder'
+    'https://docs.circuitverse.org/#/chapter4/5muxandplex?id=priority-encoder'
 PriorityEncoder.prototype.objectType = 'PriorityEncoder'

--- a/src/simulator/src/modules/RGBLed.js
+++ b/src/simulator/src/modules/RGBLed.js
@@ -172,6 +172,6 @@ RGBLed.prototype.tooltipText =
  * @type {string}
  * @category modules
  */
-RGBLed.prototype.helplink = 'https://docs.circuitverse.org/#/outputs?id=rgb-led'
+RGBLed.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/3output?id=rgbled'
 RGBLed.prototype.objectType = 'RGBLed'
 RGBLed.prototype.canShowInSubcircuit = true

--- a/src/simulator/src/modules/Random.js
+++ b/src/simulator/src/modules/Random.js
@@ -159,7 +159,7 @@ export default class Random extends CircuitElement {
 Random.prototype.tooltipText = 'Random ToolTip : Random Selected.'
 
 Random.prototype.helplink =
-    'https://docs.circuitverse.org/#/inputElements?id=random'
+    'https://docs.circuitverse.org/#/chapter4/2input?id=random'
 
 Random.prototype.objectType = 'Random'
 

--- a/src/simulator/src/modules/Rectangle.js
+++ b/src/simulator/src/modules/Rectangle.js
@@ -131,7 +131,7 @@ export default class Rectangle extends CircuitElement {
 Rectangle.prototype.tooltipText =
     'Rectangle ToolTip : Used to Box the Circuit or area you want to highlight.'
 Rectangle.prototype.helplink =
-    'https://docs.circuitverse.org/#/annotation?id=rectangle'
+    'https://docs.circuitverse.org/#/chapter4/7annotation?id=rectangle'
 Rectangle.prototype.propagationDelayFixed = true
 
 /**

--- a/src/simulator/src/modules/SevenSegDisplay.js
+++ b/src/simulator/src/modules/SevenSegDisplay.js
@@ -296,7 +296,7 @@ SevenSegDisplay.prototype.tooltipText =
  * @category modules
  */
 SevenSegDisplay.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=seven-segment-display'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=sevensegdisplay'
 SevenSegDisplay.prototype.objectType = 'SevenSegDisplay'
 SevenSegDisplay.prototype.canShowInSubcircuit = true
 SevenSegDisplay.prototype.layoutProperties = {

--- a/src/simulator/src/modules/SixteenSegDisplay.js
+++ b/src/simulator/src/modules/SixteenSegDisplay.js
@@ -464,7 +464,7 @@ SixteenSegDisplay.prototype.tooltipText =
  * @category modules
  */
 SixteenSegDisplay.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=sixteen-segment-display'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=sixteensegdisplay'
 SixteenSegDisplay.prototype.objectType = 'SixteenSegDisplay'
 SixteenSegDisplay.prototype.canShowInSubcircuit = true
 SixteenSegDisplay.prototype.layoutProperties = {

--- a/src/simulator/src/modules/SquareRGBLed.js
+++ b/src/simulator/src/modules/SquareRGBLed.js
@@ -204,7 +204,7 @@ SquareRGBLed.prototype.tooltipText =
  * @category modules
  */
 SquareRGBLed.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=square-rgb-led'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=squarergbled'
 SquareRGBLed.prototype.objectType = 'SquareRGBLed'
 SquareRGBLed.prototype.canShowInSubcircuit = true
 SquareRGBLed.prototype.layoutProperties = {

--- a/src/simulator/src/modules/Text.js
+++ b/src/simulator/src/modules/Text.js
@@ -181,7 +181,7 @@ Text.prototype.tooltipText = 'Text ToolTip: Use this to document your circuit.'
  * @category modules
  */
 Text.prototype.helplink =
-    'https://docs.circuitverse.org/#/annotation?id=adding-labels'
+    'https://docs.circuitverse.org/#/chapter4/7annotation?id=text'
 
 /**
  * @memberof Text

--- a/src/simulator/src/modules/TriState.js
+++ b/src/simulator/src/modules/TriState.js
@@ -125,5 +125,5 @@ export default class TriState extends CircuitElement {
 TriState.prototype.tooltipText =
     'TriState ToolTip : Effectively removes the output from the circuit.'
 TriState.prototype.helplink =
-    'https://docs.circuitverse.org/#/miscellaneous?id=tri-state-buffer'
+    'https://docs.circuitverse.org/#/chapter4/8misc?id=tristate-buffer'
 TriState.prototype.objectType = 'TriState'

--- a/src/simulator/src/modules/Tunnel.js
+++ b/src/simulator/src/modules/Tunnel.js
@@ -330,7 +330,7 @@ export default class Tunnel extends CircuitElement {
  */
 Tunnel.prototype.tooltipText = 'Tunnel ToolTip : Tunnel Selected.'
 Tunnel.prototype.helplink =
-    'https://docs.circuitverse.org/#/miscellaneous?id=tunnel'
+    'https://docs.circuitverse.org/#/chapter4/8misc?id=tunnel'
 
 Tunnel.prototype.overrideDirectionRotation = true
 

--- a/src/simulator/src/modules/VariableLed.js
+++ b/src/simulator/src/modules/VariableLed.js
@@ -200,6 +200,6 @@ VariableLed.prototype.mutableProperties = {
  * @category modules
  */
 VariableLed.prototype.helplink =
-    'https://docs.circuitverse.org/#/outputs?id=variable-led'
+    'https://docs.circuitverse.org/#/chapter4/3output?id=variableled'
 VariableLed.prototype.objectType = 'VariableLed'
 VariableLed.prototype.canShowInSubcircuit = true

--- a/src/simulator/src/modules/XnorGate.js
+++ b/src/simulator/src/modules/XnorGate.js
@@ -195,5 +195,5 @@ XnorGate.prototype.changeInputSize = changeInputSize
  */
 XnorGate.prototype.verilogType = 'xnor'
 XnorGate.prototype.helplink =
-    'https://docs.circuitverse.org/#/gates?id=xnor-gate'
+    'https://docs.circuitverse.org/#/chapter4/4gates?id=xnor-gate'
 XnorGate.prototype.objectType = 'XnorGate'

--- a/src/simulator/src/modules/XorGate.js
+++ b/src/simulator/src/modules/XorGate.js
@@ -183,5 +183,5 @@ XorGate.prototype.changeInputSize = changeInputSize
  * @category modules
  */
 XorGate.prototype.verilogType = 'xor'
-XorGate.prototype.helplink = 'https://docs.circuitverse.org/#/gates?id=xor-gate'
+XorGate.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/4gates?id=xor-gate'
 XorGate.prototype.objectType = 'XorGate'

--- a/src/simulator/src/sequential/DflipFlop.js
+++ b/src/simulator/src/sequential/DflipFlop.js
@@ -163,6 +163,6 @@ endmodule
 DflipFlop.prototype.tooltipText =
     'D FlipFlop ToolTip : Introduces delay in timing circuit.'
 DflipFlop.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=d-flip-flop'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=d-flip-flop'
 
 DflipFlop.prototype.objectType = 'DflipFlop'

--- a/src/simulator/src/sequential/Dlatch.js
+++ b/src/simulator/src/sequential/Dlatch.js
@@ -114,6 +114,6 @@ export default class Dlatch extends CircuitElement {
 
 Dlatch.prototype.tooltipText = 'D Latch : Single input Flip flop or D FlipFlop'
 Dlatch.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=d-latch'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=d-latch'
 
 Dlatch.prototype.objectType = 'Dlatch'

--- a/src/simulator/src/sequential/JKflipFlop.js
+++ b/src/simulator/src/sequential/JKflipFlop.js
@@ -161,6 +161,6 @@ JKflipFlop.prototype.tooltipText =
     'JK FlipFlop ToolTip : gated SR flip-flop with the addition of a clock input.'
 
 JKflipFlop.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=jk-flip-flop'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=jk-flip-flop'
 
 JKflipFlop.prototype.objectType = 'JKflipFlop'

--- a/src/simulator/src/sequential/Keyboard.js
+++ b/src/simulator/src/sequential/Keyboard.js
@@ -217,7 +217,7 @@ export default class Keyboard extends CircuitElement {
 
 Keyboard.prototype.tooltipText = 'Keyboard'
 Keyboard.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=keyboard'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=keyboard'
 
 Keyboard.prototype.mutableProperties = {
     bufferSize: {

--- a/src/simulator/src/sequential/Rom.js
+++ b/src/simulator/src/sequential/Rom.js
@@ -310,5 +310,5 @@ export default class Rom extends CircuitElement {
  * @category sequential
  */
 Rom.prototype.tooltipText = 'Read-only memory'
-Rom.prototype.helplink = 'https://docs.circuitverse.org/#/memoryElements?id=rom'
+Rom.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=rom'
 Rom.prototype.objectType = 'Rom'

--- a/src/simulator/src/sequential/SRflipFlop.js
+++ b/src/simulator/src/sequential/SRflipFlop.js
@@ -126,6 +126,6 @@ export default class SRflipFlop extends CircuitElement {
 SRflipFlop.prototype.tooltipText = 'SR FlipFlop ToolTip : SR FlipFlop Selected.'
 
 SRflipFlop.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=sr-flip-flop'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=sr-flip-flop'
 
 SRflipFlop.prototype.objectType = 'SRflipFlop'

--- a/src/simulator/src/sequential/TTY.js
+++ b/src/simulator/src/sequential/TTY.js
@@ -228,7 +228,7 @@ export default class TTY extends CircuitElement {
 }
 
 TTY.prototype.tooltipText = 'TTY ToolTip : Tele typewriter selected.'
-TTY.prototype.helplink = 'https://docs.circuitverse.org/#/Sequential?id=tty'
+TTY.prototype.helplink = 'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=tty'
 
 TTY.prototype.mutableProperties = {
     cols: {

--- a/src/simulator/src/sequential/TflipFlop.js
+++ b/src/simulator/src/sequential/TflipFlop.js
@@ -174,6 +174,6 @@ TflipFlop.prototype.tooltipText =
     'T FlipFlop ToolTip :  Changes state / Toggles whenever the clock input is strobed.'
 
 TflipFlop.prototype.helplink =
-    'https://docs.circuitverse.org/#/Sequential?id=t-flip-flop'
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=t-flip-flop'
 
 TflipFlop.prototype.objectType = 'TflipFlop'

--- a/src/simulator/src/testbench/testbenchInput.js
+++ b/src/simulator/src/testbench/testbenchInput.js
@@ -41,7 +41,7 @@ export default class TB_Input extends CircuitElement {
 
     /**
      * @memberof TB_Input
-     * Takes iput when double clicked. For help on generation of input refer to TB_Input.helplink
+     * Takes input when double clicked. For help on generation of input refer to TB_Input.helplink
      */
     dblclick() {
         this.testData = JSON.parse(prompt('Enter TestBench Json'))
@@ -328,7 +328,7 @@ TB_Input.prototype.tooltipText = 'Test Bench Input Selected'
  */
 TB_Input.prototype.centerElement = true
 
-TB_Input.prototype.helplink = 'https://docs.circuitverse.org/#/testbench'
+TB_Input.prototype.helplink = 'https://docs.circuitverse.org/#/chapter7/3testcircuits'
 
 TB_Input.prototype.mutableProperties = {
     identifier: {

--- a/src/simulator/src/testbench/testbenchOutput.js
+++ b/src/simulator/src/testbench/testbenchOutput.js
@@ -311,7 +311,7 @@ export default class TB_Output extends CircuitElement {
 }
 
 TB_Output.prototype.tooltipText = 'Test Bench Output Selected'
-TB_Output.prototype.helplink = 'https://docs.circuitverse.org/#/testbench'
+TB_Output.prototype.helplink = 'https://docs.circuitverse.org/#/chapter7/3testcircuits'
 TB_Output.prototype.centerElement = true
 TB_Output.prototype.mutableProperties = {
     identifier: {


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
Updated the helplink in all the required files (except few in which there were no such doclinks for the specific file)

### Screenshots of the changes (If any) -
If we click on the help button in properties section of any element:
![0](https://github.com/aryanndwi123/cv-frontend-vue/assets/100300789/32588391-51e1-4938-88b9-cb6b9999c9e0)

The link is redirected to PageNotFound Page (SInce the links were not updated):
![1](https://github.com/aryanndwi123/cv-frontend-vue/assets/100300789/96cecf82-d94e-4aea-a21f-21765bb381a8)

After updating the links it is being redirected to the correct links:
![2](https://github.com/aryanndwi123/cv-frontend-vue/assets/100300789/d5f6be30-e4e8-45ad-a4da-be95bc3f33ca)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 